### PR TITLE
Allow publishToMavenLocal without signing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ val ossrhUser: String? by project
 val ossrhPassword: String? by project
 
 signing {
+    setRequired { !gradle.taskGraph.hasTask(":publishToMavenLocal") }
     sign(publishing.publications)
 }
 


### PR DESCRIPTION
I want to be able to publish to Maven Local when running a local build. Currently get this error:
`> Cannot perform signing task ':signCom.ibm.cics.bundlePluginMarkerMavenPublication' because it has no configured signatory`

Not sure which would be a better solution:
`setRequired { !gradle.taskGraph.hasTask(":publishToMavenLocal") }`
or
`setRequired { gradle.taskGraph.hasTask(":publishAll") }`
or something else...

Signed-off-by: Tom Foyle <tom.foyle@uk.ibm.com>