### PR TITLE
Bump gradle publish timeouts for Sonatype, use latest publish plugin

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -4,6 +4,8 @@ set -x
 # If this is a master build then publish
 if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
   ./gradlew \
+  -Dorg.gradle.internal.http.connectionTimeout=120000 \
+  -Dorg.gradle.internal.http.socketTimeout=120000 \
   -Dorg.gradle.project.signing.keyId="$GPG_KEY_NAME" \
   -Dorg.gradle.project.signing.password="$GPG_PASSPHRASE" \
   -Dorg.gradle.project.signing.secretKeyRingFile="$GPG_SECRET_KEYRING_FILE" \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     id("groovy")
     id("java-gradle-plugin")
     id("maven-publish")
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.12.0"
     id("signing")
     `kotlin-dsl`
 }


### PR DESCRIPTION
Signed-off-by: Ledina Hido-Evans <ledina.hido@uk.ibm.com>