### PR TITLE
Add badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Editing notes:
 The table of contents is manually created and relies on the wording of the headings. Check for broken links when updating headings.
 -->
 
-# CICS bundle Gradle plugin (`com.ibm.cics.bundle`)
+# CICS bundle Gradle plugin (`com.ibm.cics.bundle`) [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/com.ibm.cics/cics-bundle-gradle/badge.svg)](https://search.maven.org/search?q=g:com.ibm.cics%20AND%20a:cics-bundle-gradle) [![Build Status](https://travis-ci.com/IBM/cics-bundle-gradle.svg?branch=master)](https://travis-ci.com/IBM/cics-bundle-gradle) [![Nexus Snapshots](https://img.shields.io/nexus/s/com.ibm.cics/cics-bundle-gradle.svg?server=https%3A%2F%2Foss.sonatype.org&label=snapshot&color=success)](https://oss.sonatype.org/#nexus-search;gav~com.ibm.cics~cics-bundle-gradle~~~)
 
 - [About this project](#cics-bundle-gradle-plugin-comibmcicsbundle)
 - The CICS bundle Gradle plugin


### PR DESCRIPTION
Badges, which we already have on the Maven and Common repos, provide quick access to the build and artifacts and quickly show what the most recent version is.