### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, "*" ]
+    branches: [ main, "*" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '45 18 * * 0'
 

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -x
 
-# If this is a master build then publish
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+# If this is a main build then publish
+if [ "$TRAVIS_BRANCH" = 'main' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
   ./gradlew \
   -Dorg.gradle.internal.http.connectionTimeout=120000 \
   -Dorg.gradle.internal.http.socketTimeout=120000 \

--- a/.travis/setup-signing.sh
+++ b/.travis/setup-signing.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -x
 
-# If this is a master build then lay out signing information
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+# If this is a main build then lay out signing information
+if [ "$TRAVIS_BRANCH" = 'main' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
   openssl aes-256-cbc -K $encrypted_cfe97df84ed0_key -iv $encrypted_cfe97df84ed0_iv -in .travis/signingkey.asc.enc -out .travis/signingkey.asc -d
   gpg --version
   gpg --fast-import .travis/signingkey.asc

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Their dependencies are as follows:
 
 ## Configure the CICS bundle Gradle plugin
 To use the plugin, you may either:
- * Add the CICS bundle configuration into an existing Gradle Java project, such as a WAR project. This will give you a single standalone project containing both the Java application and the CICS bundle configuration. The [Standalone project sample (`gradle-war-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/master/samples/gradle-war-sample) shows this case.  
- * Create a separate Gradle module to contain the CICS bundle configuration. This will give you a multi-part project where the CICS bundle configuration is kept separate from the Java application. The [Multi-part project sample (`gradle-multipart-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/master/samples/gradle-multipart-sample) shows this case.  
+ * Add the CICS bundle configuration into an existing Gradle Java project, such as a WAR project. This will give you a single standalone project containing both the Java application and the CICS bundle configuration. The [Standalone project sample (`gradle-war-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/main/samples/gradle-war-sample) shows this case.  
+ * Create a separate Gradle module to contain the CICS bundle configuration. This will give you a multi-part project where the CICS bundle configuration is kept separate from the Java application. The [Multi-part project sample (`gradle-multipart-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/main/samples/gradle-multipart-sample) shows this case.  
 
 In either case, configure the Gradle module as follows:
 
@@ -240,10 +240,10 @@ cicsBundle {
  
 ## Samples
 Use of this plugin will vary depending on what you’re starting with and the structure of your project, for example, whether you'd like to create a separate Gradle module for the bundle configuration or you'd like to include it into your existing module. We have included some samples to demonstrate the different methods.  
-[Multi-part project sample (`gradle-multipart-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/master/samples/gradle-multipart-sample)    
+[Multi-part project sample (`gradle-multipart-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/main/samples/gradle-multipart-sample)    
 This sample is the quickest way to try the plugin out if you don't already have a Gradle project. It shows how to configure a multi-part Gradle project to build and deploy a CICS bundle, with a separate module to contain bundle configurations. The sample has a parent Gradle project that contains a local and a remote JAVA project as child modules. It also contains a CICS child module that wraps the other two modules into a CICS bundle and deploys the built bundle to CICS. A `README` is included in the sample with detailed instructions.
 
-[Standalone project sample (`gradle-war-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/master/samples/gradle-war-sample)  
+[Standalone project sample (`gradle-war-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/main/samples/gradle-war-sample)  
 If you already have a Gradle module and want to add extra configuration to it for quick use of the plugin, check out this sample. It shows you how to configure an existing WAR project to build a CICS bundle. You can either copy and paste the configuration to your WAR project or import the full sample to see how it works. A `README` is included in the sample with detailed instructions.
 
 ## Troubleshooting


### PR DESCRIPTION
This changes build and other references to the `master` branch to use `main` instead.