### PR TITLE
Use env variables instead of project properties for publishing credentials.

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -29,8 +29,8 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhUser: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           # Authenticate to GPP
-          ORG_GRADLE_PROJECT_gradle.publish.key: ${{ secrets.GPP_KEY }}
-          ORG_GRADLE_PROJECT_gradle.publish.secret: ${{ secrets.GPP_SECRET }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.GPP_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GPP_SECRET }}
       
       - name: Build with Gradle
         if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
This is the staid version of #108.