### PR TITLE
Release 1.0.3

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Build Gradle War Sample
         working-directory: ./samples/gradle-war-sample
-        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace
+        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace --include-build ../..
 
       - name: Build Gradle Multipart Sample
         working-directory: ./samples/gradle-multipart-sample
-        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace
+        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace --include-build ../..

--- a/.github/workflows/gradle-scheduled-build.yml
+++ b/.github/workflows/gradle-scheduled-build.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Build Gradle War Sample
         working-directory: ./samples/gradle-war-sample
-        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace
+        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace --include-build ../..
 
       - name: Build Gradle Multipart Sample
         working-directory: ./samples/gradle-multipart-sample
-        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace
+        run: ./gradlew build -PcicsUser=user -PcicsPass=pass --no-daemon --info --stacktrace --include-build ../..

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ In either case, configure the Gradle module as follows:
 1. Add the plugin id to your `build.gradle`.
     ```gradle
     plugins {
-        id 'com.ibm.cics.bundle' version '1.0.2'
+        id 'com.ibm.cics.bundle' version '1.0.3'
     }
     ```
 1. If using a snapshot version of the plugin, add the snapshot repository to your `settings.gradle`, so Gradle can find the plugin.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "com.ibm.cics"
-version = "1.0.3-SNAPSHOT"
+version = "1.0.3"
 val isReleaseVersion by extra(!version.toString().endsWith("SNAPSHOT"))
 
 gradlePlugin {

--- a/samples/gradle-multipart-sample/gradle-bundle-demo/build.gradle
+++ b/samples/gradle-multipart-sample/gradle-bundle-demo/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.ibm.cics.bundle' version '1.0.2'
+    id 'com.ibm.cics.bundle' version '1.0.3'
 }
 
 group 'com.ibm.cics'

--- a/samples/gradle-war-sample/standalone-war-demo/build.gradle
+++ b/samples/gradle-war-sample/standalone-war-demo/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.ibm.cics.bundle' version '1.0.2'
+    id 'com.ibm.cics.bundle' version '1.0.3'
     id 'war'
 }
 


### PR DESCRIPTION
In addition to updating the version to 1.0.3, this PR also uses the `--include-build` capability to have the samples use the plugin that has been built in the previous step, so they don't read the plugin from the repositories and therefore have to stay a step behind.