### PR TITLE
Use BND plugin instead of deprecated OSGi plugin. Use latest Gradle 7.4.2 in tests.

### DIFF
--- a/src/test/groovy/com/ibm/cics/cbgp/AbstractTest.groovy
+++ b/src/test/groovy/com/ibm/cics/cbgp/AbstractTest.groovy
@@ -151,7 +151,7 @@ abstract class AbstractTest extends Specification {
 				.withArguments(args)
 				.withPluginClasspath()
 				.withDebug(isDebug)
-				.withGradleVersion("5.0")
+				.withGradleVersion("7.4.2")
 
 		if (!failExpected) {
 			result = gradleRunner.build()

--- a/src/test/groovy/com/ibm/cics/cbgp/GoldenPathTests.groovy
+++ b/src/test/groovy/com/ibm/cics/cbgp/GoldenPathTests.groovy
@@ -35,7 +35,6 @@ class GoldenPathTests extends AbstractTest {
 
 		then:
 		checkBuildOutputStrings(result, [
-				"(Gradle 5.0)",
 				"Task :buildCICSBundle",
 				"Task :packageCICSBundle",
 				"No Java-based bundle parts found in 'cicsBundlePart' dependency configuration",

--- a/src/test/resources/extra-config-project/extra-config-ear-osgi/build.gradle
+++ b/src/test/resources/extra-config-project/extra-config-ear-osgi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder' version '6.3.0'
 }
 
 version '1.0.0'
@@ -16,8 +16,8 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes(
+    bundle {
+        bnd (
                 'Bundle-SymbolicName': 'com.ibm.cics.extra-config-ear-osgi',
                 'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
         )

--- a/src/test/resources/extra-config-project/extra-config-osgi/build.gradle
+++ b/src/test/resources/extra-config-project/extra-config-osgi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder' version '6.3.0'
 }
 
 version '1.0.0'
@@ -16,8 +16,8 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes(
+    bundle {
+        bnd (
                 'Bundle-SymbolicName': 'com.ibm.cics.extra-config-osgi',
                 'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
         )

--- a/src/test/resources/multi-project/multi-ear-osgi/build.gradle
+++ b/src/test/resources/multi-project/multi-ear-osgi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder' version '6.3.0'
 }
 
 version '1.0.0'
@@ -16,8 +16,8 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes(
+    bundle {
+        bnd (
                 'Bundle-SymbolicName': 'com.ibm.cics.multi-ear-osgi',
                 'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
         )

--- a/src/test/resources/multi-project/multi-osgi/build.gradle
+++ b/src/test/resources/multi-project/multi-osgi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder' version '6.3.0'
 }
 
 version '1.0.0'
@@ -16,8 +16,8 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes(
+    bundle {
+        bnd (
                 'Bundle-SymbolicName': 'com.ibm.cics.multi-osgi',
                 'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
         )

--- a/src/test/resources/standalone-ear/standalone-ear-osgi/build.gradle
+++ b/src/test/resources/standalone-ear/standalone-ear-osgi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder' version '6.3.0'
 }
 
 version '1.0.0'
@@ -16,8 +16,8 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes(
+    bundle {
+        bnd (
                 'Bundle-SymbolicName': 'com.ibm.cics.standalone-ear-osgi',
                 'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
         )

--- a/src/test/resources/standalone-osgi/build.gradle
+++ b/src/test/resources/standalone-osgi/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'java'
-    id 'osgi'
+    id 'biz.aQute.bnd.builder' version "6.3.0"
     id 'com.ibm.cics.bundle'
 }
 
@@ -18,8 +17,8 @@ dependencies {
 }
 
 jar {
-    manifest {
-        attributes(
+    bundle{
+        bnd (
                 'Bundle-SymbolicName': 'com.ibm.cics.standalone-osgi',
                 'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
         )


### PR DESCRIPTION
Signed-off-by: Tom Foyle <tom.foyle@uk.ibm.com>