### PR TITLE
Osgi version range support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 build/
 \.gradle/
 \.idea/

--- a/README.md
+++ b/README.md
@@ -210,12 +210,15 @@ When adding Java-based bundle parts to your CICS bundle, the following defaults 
 * The `name` of the bundle part will be equal to the file name.
 * The `jvmserver` of the bundle part will be equal to the vaule of the `defaultJVMServer` property in the `cicsBundle` extension.
 * The type of the bundle part will be determined by the file extension, e.g. a `.jar` extension will result in an OSGi bundle part.
+* Any version ranges will be ignored and the version in the build file will be used when generating the bundlepart file
 
 For the majority of users, these defaults will be sufficient. However, for advanced users, any of the defaults can be overriden with specific values by wrapping your `cicsBundlePart` dependency declaration inside one of the following types:
 * `cicsBundleOsgi`
 * `cicsBundleWar`
 * `cicsBundleEar`
 * `cicsBundleEba`
+
+> NOTE: Only `cicsBundleOsgi` supports version range
 
 You may use either the closure syntax or map syntax to specify the values:
 ```gradle
@@ -238,7 +241,18 @@ cicsBundle {
     }
 }
 ```
- 
+For phase-in support when deploying a bundle, include a version range on a cicsBundleOsgi dependency:
+```gradle
+dependencies {
+    cicsBundleOsgi {
+        // Specify dependency as normal using any of the usual notations.
+        dependency = cicsBundlePart 'org.codehaus.cargo:simple-jar:1.7.7@jar'
+        // Specify a version range
+        versionRange = "[1.0.0,2.0.0)"
+    }
+}
+```
+
 ## Samples
 Use of this plugin will vary depending on what you’re starting with and the structure of your project, for example, whether you'd like to create a separate Gradle module for the bundle configuration or you'd like to include it into your existing module. We have included some samples to demonstrate the different methods.  
 [Multi-part project sample (`gradle-multipart-sample`)](https://github.com/IBM/cics-bundle-gradle/tree/main/samples/gradle-multipart-sample)    

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,7 @@ repositories {
 defaultTasks("build")
 
 dependencies {
-    implementation("com.ibm.cics:cics-bundle-common:1.0.4")
+    implementation("com.ibm.cics:cics-bundle-common:1.0.5-SNAPSHOT")
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.32.0")
     testImplementation(enforcedPlatform("org.spockframework:spock-bom:2.0-groovy-3.0"))

--- a/samples/gradle-multipart-sample/settings.gradle
+++ b/samples/gradle-multipart-sample/settings.gradle
@@ -4,10 +4,10 @@ pluginManagement {
         gradlePluginPortal() // Needed for the plugin's own dependencies.
         //mavenLocal() //enable this to test a local version published using publishToMavenLocal goal
         //uncomment lines below to use Sonatype snapshots
-        //maven {
-        //    name = "SonatypeSnapshots"
-        //    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-        //}
+        maven {
+            name = "SonatypeSnapshots"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+        }
     }
 }
 rootProject.name = 'gradle-multipart-sample'

--- a/samples/gradle-war-sample/settings.gradle
+++ b/samples/gradle-war-sample/settings.gradle
@@ -4,10 +4,10 @@ pluginManagement {
         gradlePluginPortal() // Needed for the plugin's own dependencies.
         //mavenLocal() //enable this to test a local version published using publishToMavenLocal goal
         //uncomment lines below to use Sonatype snapshots
-        //maven {
-        //    name = "SonatypeSnapshots"
-        //    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-        //}
+        maven {
+            name = "SonatypeSnapshots"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+        }
     }
 }
 rootProject.name = 'gradle-war-sample'

--- a/src/main/kotlin/com/ibm/cics/cbgp/AbstractJavaBundlePartBinding.kt
+++ b/src/main/kotlin/com/ibm/cics/cbgp/AbstractJavaBundlePartBinding.kt
@@ -2,7 +2,7 @@
  * #%L
  * CICS Bundle Gradle Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ abstract class AbstractJavaBundlePartBinding() : AbstractBundlePartBinding() {
 
 	var name: String = ""
 	var jvmserver: String = ""
+	var versionRange: String = ""
 
 	@Throws(GradleException::class)
 	override fun applyDefaults(defaultJVMServer: String) {
@@ -46,6 +47,12 @@ abstract class AbstractJavaBundlePartBinding() : AbstractBundlePartBinding() {
 		}
 	}
 
+	fun applyVersionRange(range: String){
+		if(versionRange.isEmpty()) {
+			versionRange = range
+		}
+	}
+
 	fun extraConfigAsString(): String {
 		val map = LinkedHashMap<String, String>()
 		if (name.isNotEmpty()) {
@@ -53,6 +60,9 @@ abstract class AbstractJavaBundlePartBinding() : AbstractBundlePartBinding() {
 		}
 		if (jvmserver.isNotEmpty()) {
 			map["jvmserver"] = jvmserver
+		}
+		if(versionRange.isNotEmpty()) {
+			map["versionRange"] = versionRange
 		}
 		return map.toString()
 	}

--- a/src/main/kotlin/com/ibm/cics/cbgp/BuildBundleTask.kt
+++ b/src/main/kotlin/com/ibm/cics/cbgp/BuildBundleTask.kt
@@ -2,7 +2,7 @@
  * #%L
  * CICS Bundle Gradle Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,8 @@ open class BuildBundleTask : DefaultTask() {
 	val defaultJVMServer = bundleExtension.build.defaultJVMServer
 	@Input
 	val bundlePartsDirectory = "src/main/${bundleExtension.build.bundlePartsDirectory}"
+	@Input
+	val osgiVersionRange = bundleExtension.build.osgiVersionRange
 
 	/**
 	 * Set parameters from the extraConfig extension as task inputs.
@@ -119,6 +121,7 @@ open class BuildBundleTask : DefaultTask() {
 
 	private fun addJavaBundlePartsToBundle(bundlePublisher: BundlePublisher) {
 		logger.lifecycle("Adding Java-based bundle parts from '${BundlePlugin.BUNDLE_DEPENDENCY_CONFIGURATION_NAME}' dependency configuration")
+
 		val resolved = cicsBundlePartConfig.resolvedConfiguration
 		if (resolved.hasError()) {
 			throw GradleException("Failed to resolve Java-based bundle parts from '${BundlePlugin.BUNDLE_DEPENDENCY_CONFIGURATION_NAME}' dependency configuration")
@@ -147,6 +150,7 @@ open class BuildBundleTask : DefaultTask() {
 			}
 			binding.file = file
 			binding.applyDefaults(defaultJVMServer)
+			binding.applyVersionRange(osgiVersionRange)
 
 			try {
 				bundlePublisher.addResource(binding.toBundlePart())

--- a/src/main/kotlin/com/ibm/cics/cbgp/BundleBuildExtension.kt
+++ b/src/main/kotlin/com/ibm/cics/cbgp/BundleBuildExtension.kt
@@ -3,4 +3,5 @@ package com.ibm.cics.cbgp
 open class BundleBuildExtension {
 	var defaultJVMServer = ""
 	var bundlePartsDirectory = "bundleParts"
+	var osgiVersionRange = ""
 }

--- a/src/main/kotlin/com/ibm/cics/cbgp/OsgiBundlePartBinding.kt
+++ b/src/main/kotlin/com/ibm/cics/cbgp/OsgiBundlePartBinding.kt
@@ -2,7 +2,7 @@
  * #%L
  * CICS Bundle Gradle Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ package com.ibm.cics.cbgp
 import com.ibm.cics.bundle.parts.BundleResource
 import com.ibm.cics.bundle.parts.OsgiBundlePart
 import org.gradle.api.GradleException
-import java.io.File
 import java.io.IOException
 
 class OsgiBundlePartBinding() : AbstractJavaBundlePartBinding() {
@@ -51,12 +50,22 @@ class OsgiBundlePartBinding() : AbstractJavaBundlePartBinding() {
 	}
 
 	override fun toBundlePart(): BundleResource {
-		return OsgiBundlePart(
+		val bundlePart = OsgiBundlePart(
 				name,
 				symbolicName,
 				osgiVersion,
 				jvmserver,
 				file
-		)
+		);
+		bundlePart.versionRange = getRange();
+		return bundlePart;
+	}
+
+	 private fun getRange(): String {
+		 return if(versionRange.isNotEmpty() && versionRange.contains(",")) {
+			 versionRange
+		 } else {
+			 "";
+		 }
 	}
 }

--- a/src/test/groovy/com/ibm/cics/cbgp/GoldenPathTests.groovy
+++ b/src/test/groovy/com/ibm/cics/cbgp/GoldenPathTests.groovy
@@ -2,7 +2,7 @@
  * #%L
  * CICS Bundle Gradle Plugin
  * %%
- * Copyright (C) 2019 IBM Corp.
+ * Copyright (C) 2019, 2023 IBM Corp.
  * %%
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -62,6 +62,51 @@ class GoldenPathTests extends AbstractTest {
 		then:
 		checkBundleArchiveFile()
 	}
+
+	def "Test OSGi with version range"() {
+
+		given:
+		rootProjectName = bundleProjectName = "bundle-osgi-versionrange"
+		projectVersion = "1.0.0"
+
+		def jvmsOsgi = "DFHWLP"
+		def bindingExtension = "osgibundle"
+		def versionRange = "[1.0.0,2.0.0)"
+		def subProjectName = "multi-osgi"
+
+		copyTestProject()
+
+		when:
+		runGradleAndSucceed([BundlePlugin.DEPLOY_TASK_NAME])
+
+		then:
+		checkFileContains(getFileInDir(bundleBuildDir, "${subProjectName + "-" + projectVersion}.${bindingExtension}") , ["<${bindingExtension} jvmserver=\"${jvmsOsgi}\" symbolicname=\"com.ibm.cics.multi-osgi\" version=\"\" versionRange=\"${versionRange}\"/>"])
+		checkBundleArchiveFile()
+	}
+	def "Test multiple OSGi with version range"() {
+
+		given:
+		rootProjectName = bundleProjectName = "bundle-osgi-versionrange-multi"
+		projectVersion = "1.0.0"
+
+		def jvmsOsgi = "DFHWLP"
+		def bindingExtension = "osgibundle"
+		def versionRange = "[1.0.0,2.0.0)"
+		def versionRangeTwo = "[1.0.0,3.0.0)"
+		def subProjectName = "multi-osgi"
+		def subProjectNameTwo = "multi-osgi-repeat"
+
+		copyTestProject()
+
+		when:
+		runGradleAndSucceed([BundlePlugin.DEPLOY_TASK_NAME])
+
+		then:
+		checkFileContains(getFileInDir(bundleBuildDir, "${subProjectName + "-" + projectVersion}.${bindingExtension}") , ["<${bindingExtension} jvmserver=\"${jvmsOsgi}\" symbolicname=\"com.ibm.cics.multi-osgi\" version=\"\" versionRange=\"${versionRange}\"/>"])
+		checkFileContains(getFileInDir(bundleBuildDir, "${subProjectNameTwo + "-" + projectVersion}.${bindingExtension}") , ["<${bindingExtension} jvmserver=\"${jvmsOsgi}\" symbolicname=\"com.ibm.cics.multi-osgi-repeat\" version=\"\" versionRange=\"${versionRangeTwo}\"/>"])
+		checkBundleArchiveFile()
+	}
+
 
 	@Unroll
 	def "Test standalone #type project"(String type) {

--- a/src/test/resources/bundle-osgi-versionrange-multi/build.gradle
+++ b/src/test/resources/bundle-osgi-versionrange-multi/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id "com.ibm.cics.bundle" version '1.0.3'
+}
+
+group 'com.ibm.cics'
+version '1.0.0'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+
+cicsBundle {
+    build {
+        defaultJVMServer = 'DFHWLP'
+    }
+    deploy {
+        url = project.url
+        cicsplex = project.cicsplex
+        region = project.region
+        bunddef = 'GRADLESW'
+        csdgroup = project.csdgroup
+        username = project.username
+        password = project.password
+        insecure = project.insecure
+    }
+}
+
+dependencies {
+    cicsBundleOsgi {
+        dependency = cicsBundlePart project(path: ':multi-osgi', configuration:'archives')
+        versionRange = "[1.0.0,2.0.0)"
+    }
+    cicsBundleOsgi {
+        dependency = cicsBundlePart project(path: ':multi-osgi-repeat', configuration:'archives')
+        versionRange = "[1.0.0,3.0.0)"
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi-repeat/build.gradle
+++ b/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi-repeat/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'biz.aQute.bnd.builder' version '6.3.0'
+}
+
+version '1.0.0'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation (group: 'com.ibm.cics', name: 'com.ibm.cics.server', version: '1.700.1-5.5-PH11872')
+}
+
+jar {
+    bundle {
+        bnd (
+                'Bundle-SymbolicName': 'com.ibm.cics.multi-osgi-repeat',
+                'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
+        )
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi-repeat/src/main/java/examples/hello/HelloCICSWorld.java
+++ b/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi-repeat/src/main/java/examples/hello/HelloCICSWorld.java
@@ -1,0 +1,16 @@
+package examples.hello;
+
+import com.ibm.cics.server.CommAreaHolder;
+import com.ibm.cics.server.Task;
+
+public class HelloCICSWorld {
+    public static void main(CommAreaHolder CAH) {
+        Task t = Task.getTask();
+        if (t == null) {
+            System.err.println("examples.hello.HelloCICSWorld example: Can't get Task");
+        }
+        else {
+            t.out.println("Hello from a Java CICS application");
+        }
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi-repeat/src/main/java/examples/hello/HelloWorld.java
+++ b/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi-repeat/src/main/java/examples/hello/HelloWorld.java
@@ -1,0 +1,7 @@
+package examples.hello;
+
+public class HelloWorld {
+	public static void main(String args[]) {
+		System.out.println("Hello from a regular Java application");
+	}
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi/build.gradle
+++ b/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'biz.aQute.bnd.builder' version '6.3.0'
+}
+
+version '1.0.0'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation (group: 'com.ibm.cics', name: 'com.ibm.cics.server', version: '1.700.1-5.5-PH11872')
+}
+
+jar {
+    bundle {
+        bnd (
+                'Bundle-SymbolicName': 'com.ibm.cics.multi-osgi',
+                'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
+        )
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi/src/main/java/examples/hello/HelloCICSWorld.java
+++ b/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi/src/main/java/examples/hello/HelloCICSWorld.java
@@ -1,0 +1,16 @@
+package examples.hello;
+
+import com.ibm.cics.server.CommAreaHolder;
+import com.ibm.cics.server.Task;
+
+public class HelloCICSWorld {
+    public static void main(CommAreaHolder CAH) {
+        Task t = Task.getTask();
+        if (t == null) {
+            System.err.println("examples.hello.HelloCICSWorld example: Can't get Task");
+        }
+        else {
+            t.out.println("Hello from a Java CICS application");
+        }
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi/src/main/java/examples/hello/HelloWorld.java
+++ b/src/test/resources/bundle-osgi-versionrange-multi/multi-osgi/src/main/java/examples/hello/HelloWorld.java
@@ -1,0 +1,7 @@
+package examples.hello;
+
+public class HelloWorld {
+	public static void main(String args[]) {
+		System.out.println("Hello from a regular Java application");
+	}
+}

--- a/src/test/resources/bundle-osgi-versionrange-multi/settings.gradle
+++ b/src/test/resources/bundle-osgi-versionrange-multi/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'bundle-osgi-versionrange-multi'
+
+include ':multi-osgi'
+include ':multi-osgi-repeat'

--- a/src/test/resources/bundle-osgi-versionrange/build.gradle
+++ b/src/test/resources/bundle-osgi-versionrange/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id "com.ibm.cics.bundle" version '1.0.3'
+}
+
+group 'com.ibm.cics'
+version '1.0.0'
+
+repositories {
+    mavenLocal()
+}
+
+cicsBundle {
+    build {
+        defaultJVMServer = 'DFHWLP'
+    }
+    deploy {
+        url = project.url
+        cicsplex = project.cicsplex
+        region = project.region
+        bunddef = 'GRADLESW'
+        csdgroup = project.csdgroup
+        username = project.username
+        password = project.password
+        insecure = project.insecure
+    }
+}
+
+dependencies {
+    cicsBundleOsgi {
+        dependency = cicsBundlePart project(path: 'multi-osgi', configuration: 'archives')
+        versionRange = "[1.0.0,2.0.0)"
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange/multi-osgi/build.gradle
+++ b/src/test/resources/bundle-osgi-versionrange/multi-osgi/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'biz.aQute.bnd.builder' version '6.3.0'
+}
+
+version '1.0.0'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation (group: 'com.ibm.cics', name: 'com.ibm.cics.server', version: '1.700.1-5.5-PH11872')
+}
+
+jar {
+    bundle {
+        bnd (
+                'Bundle-SymbolicName': 'com.ibm.cics.multi-osgi',
+                'CICS-MainClass': 'examples.hello.HelloCICSWorld, examples.hello.HelloWorld'
+        )
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange/multi-osgi/src/main/java/examples/hello/HelloCICSWorld.java
+++ b/src/test/resources/bundle-osgi-versionrange/multi-osgi/src/main/java/examples/hello/HelloCICSWorld.java
@@ -1,0 +1,16 @@
+package examples.hello;
+
+import com.ibm.cics.server.CommAreaHolder;
+import com.ibm.cics.server.Task;
+
+public class HelloCICSWorld {
+    public static void main(CommAreaHolder CAH) {
+        Task t = Task.getTask();
+        if (t == null) {
+            System.err.println("examples.hello.HelloCICSWorld example: Can't get Task");
+        }
+        else {
+            t.out.println("Hello from a Java CICS application");
+        }
+    }
+}

--- a/src/test/resources/bundle-osgi-versionrange/multi-osgi/src/main/java/examples/hello/HelloWorld.java
+++ b/src/test/resources/bundle-osgi-versionrange/multi-osgi/src/main/java/examples/hello/HelloWorld.java
@@ -1,0 +1,7 @@
+package examples.hello;
+
+public class HelloWorld {
+	public static void main(String args[]) {
+		System.out.println("Hello from a regular Java application");
+	}
+}

--- a/src/test/resources/bundle-osgi-versionrange/settings.gradle
+++ b/src/test/resources/bundle-osgi-versionrange/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'bundle-osgi-versionrange'
+
+include ':multi-osgi'


### PR DESCRIPTION
Adds support for OSGi version ranges, and updates the README to have information on how to use them.

Relies on a change (https://github.com/IBM/cics-bundle-common/pull/63) going into `cics-bundle-common` before this is merged.