### PR TITLE
avoid creating new publication and customise the automated pluginMaven publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,16 +75,18 @@ publishing {
             }
         }
     }
-     publications {
-         create<MavenPublication>("mavenJava") {
-            from(components["java"])
-            pom {
-                name.set("CICS Bundle Gradle")
-                description.set("A Gradle plugin to build CICS bundles, and deploy them into CICS TS")
-                licenses {
-                    license {
-                        name.set("EPL-2.0")
-                        url .set("https://www.eclipse.org/legal/epl-2.0/")
+    publications {
+        // Access the 'pluginMaven' publication to update its POM metadata
+        withType<MavenPublication>().configureEach {
+            if (name == "pluginMaven") {
+                pom {
+                    name.set("CICS Bundle Gradle")
+                    description.set("A Gradle plugin to build CICS bundles, and deploy them into CICS TS")
+                    licenses {
+                        license {
+                            name.set("EPL-2.0")
+                            url.set("https://www.eclipse.org/legal/epl-2.0/")
+                        }
                     }
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "com.ibm.cics"
-version = "1.0.6-SNAPSHOT"
+version = "1.0.7-SNAPSHOT"
 val isReleaseVersion by extra(!version.toString().endsWith("SNAPSHOT"))
 
 gradlePlugin {


### PR DESCRIPTION
The output was generating two separate poms, only one of which was uploaded. Unfortunately this was the pom without that description in.

This PR updates the output to all be in one pom. And increments the version number to 1.0.7-SNAPSHOT.