### PR TITLE
Prepare for development of 1.0.8-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "com.ibm.cics"
-version = "1.0.7"
+version = "1.0.8-SNAPSHOT"
 val isReleaseVersion by extra(!version.toString().endsWith("SNAPSHOT"))
 
 gradlePlugin {


### PR DESCRIPTION
Depends on #163 and releasing it to Maven Central and GPP.