### PR TITLE
Drop support for EOL Gradle 7 to allow updating to Jackson 2.21

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          # We specifically need Java 17 as it's the only one which supports every Gradle version we build/test with (7, 8, and 9).
-          java-version: '17'
+          # Java 21 is required for Jackson 2.21 and supports Gradle 8 and 9.
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
       

--- a/.github/workflows/gradle-scheduled-build.yml
+++ b/.github/workflows/gradle-scheduled-build.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          # Java 21 is required for Jackson 2.21 and supports Gradle 8 and 9.
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ This project contains:
   * `samples`, a collection of samples that show different ways of using this plugin.
 
 ## Supported Gradle versions
-The CICS bundle Gradle plugin supports Gradle 7 to Gradle 9.
+The CICS bundle Gradle plugin supports Gradle 8 and 9.
+
+**Note:** Gradle 7 support was removed in version 1.0.9 to enable Java 21 compatibility.
 
 ## Supported bundle part types
 The CICS bundle Gradle plugin supports building CICS bundles that contain the following bundle parts:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle-multipart-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-multipart-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle-osgi-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-osgi-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle-war-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-war-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/com/ibm/cics/cbgp/GradleVersions.groovy
+++ b/src/test/groovy/com/ibm/cics/cbgp/GradleVersions.groovy
@@ -2,7 +2,7 @@ package com.ibm.cics.cbgp
 
 abstract class GradleVersions {
 
-    static List GRADLE_VERSIONS = ["7.6.1", "8.5", "9.4.1"]
+    static List GRADLE_VERSIONS = ["8.5", "9.4.1"]
 
     static List onAllVersions(List inputs) {
         [GRADLE_VERSIONS, inputs]

--- a/src/test/groovy/com/ibm/cics/cbgp/GradleVersions.groovy
+++ b/src/test/groovy/com/ibm/cics/cbgp/GradleVersions.groovy
@@ -2,7 +2,7 @@ package com.ibm.cics.cbgp
 
 abstract class GradleVersions {
 
-    static List GRADLE_VERSIONS = ["8.5", "9.4.1"]
+    static List GRADLE_VERSIONS = ["8.14.5", "9.5.1"]
 
     static List onAllVersions(List inputs) {
         [GRADLE_VERSIONS, inputs]


### PR DESCRIPTION
This change is necessary in order for us to update to Jackson 2.21 (which is in cics-bundle-common 2.0.3) because Jackson 2.21 requires Java 21, which is not supported by Gradle 7. Gradle 7 is end of life now, so I don't think this is a big problem. However, as this is a breaking change (Gradle 7 users must update to a newer Gradle and to Java 21), I think we should also make this a 2.0 release of the plugin, but I plan to do that in a follow-up PR.