### PR TITLE
Upgrade to latest Gradle versions

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle-multipart-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-multipart-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle-osgi-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-osgi-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/gradle-war-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-war-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/com/ibm/cics/cbgp/GradleVersions.groovy
+++ b/src/test/groovy/com/ibm/cics/cbgp/GradleVersions.groovy
@@ -2,7 +2,7 @@ package com.ibm.cics.cbgp
 
 abstract class GradleVersions {
 
-    static List GRADLE_VERSIONS = ["7.6.1", "8.5", "9.4.1"]
+    static List GRADLE_VERSIONS = ["7.6.6", "8.14.5", "9.5.1"]
 
     static List onAllVersions(List inputs) {
         [GRADLE_VERSIONS, inputs]


### PR DESCRIPTION
Turns out that the Java 21 related build errors we were seeing with Jackson 2.21 were caused by this:
https://github.com/FasterXML/jackson-core/issues/1210

And it has been fixed in later versions of Gradle 7, so we don't need to drop support for Gradle 7 after all!